### PR TITLE
Adds the option to verify the SSL connection

### DIFF
--- a/tpm.py
+++ b/tpm.py
@@ -15,6 +15,11 @@ Or with Private/Public Key
     >>> privkey = '87324bedead51af96a45271d217b8ad5ef3f220da6c078a9bce4e4318729189c'
     >>> tpmconn = tpm.TpmApiv4(URL, private_key=privkey, public_key=pubkey)
 
+Optionally, you can specify whether you wish to verify the SSL connection:
+    >>> tpmconn = tpm.TpmApiv4(URL, verify=True, ...
+or set the path to the CA certificate bundle or directory:
+    >>> tpmconn = tpm.TpmApiv4(URL, verify='path/to/certfile', ...
+
 With the connection object you can use all TPM functions, like list all passwords:
     >>> tpmconn.list_passwords()
 
@@ -101,6 +106,7 @@ class TpmApi(object):
         self.username = False
         self.password = False
         self.unlock_reason = False
+        self.verify = False
         for key in kwargs:
             if key == 'private_key':
                 self.private_key = kwargs[key]
@@ -112,6 +118,8 @@ class TpmApi(object):
                 self.password = kwargs[key]
             elif key == 'unlock_reason':
                 self.unlock_reason = kwargs[key]
+            elif key == 'verify':
+                self.verify = kwargs[key]
         if self.private_key is not False and self.public_key is not False and\
                 self.username is False and self.password is False:
             log.debug('Using Private/Public Key authentication.')
@@ -165,20 +173,20 @@ class TpmApi(object):
             if action == 'get':
                 log.debug('GET request %s' % url)
                 self.req = requests.get(url, headers=self.headers, auth=auth,
-                                        verify=False)
+                                        verify=self.verify)
             elif action == 'post':
                 log.debug('POST request %s' % url)
                 self.req = requests.post(url, headers=self.headers, auth=auth,
-                                         verify=False, data=data)
+                                         verify=self.verify, data=data)
             elif action == 'put':
                 log.debug('PUT request %s' % url)
                 self.req = requests.put(url, headers=self.headers,
-                                        auth=auth, verify=False,
+                                        auth=auth, verify=self.verify,
                                         data=data)
             elif action == 'delete':
                 log.debug('DELETE request %s' % url)
                 self.req = requests.delete(url, headers=self.headers,
-                                           verify=False, auth=auth)
+                                           verify=self.verify, auth=auth)
 
             if self.req.content == b'':
                 result = None


### PR DESCRIPTION
Currently the default setting to verify SSL connections in the library is set to `False`. The requests library also allows for [setting custom CA bundles](https://requests.kennethreitz.org/en/master/user/advanced/#ssl-cert-verification) which I added as an option to the TPM API.