### PR TITLE
docs: add TPM banner and maintenance support wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # tpm.py
 
+> Modern Python SDK groundwork for TeamPasswordManager with safer API boundaries and maintainable packaging.
+
 [![Build Status](https://travis-ci.org/peshay/tpm.svg?branch=master)](https://travis-ci.org/peshay/tpm)
 [![Codecov](https://codecov.io/gh/peshay/tpm/branch/master/graph/badge.svg)](https://codecov.io/gh/peshay/tpm/branch/master)
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/peshay/tpm.svg)](https://scrutinizer-ci.com/g/peshay/tpm/)
 [![Python version](https://img.shields.io/pypi/pyversions/tpm.svg)](https://pypi.python.org/pypi/tpm)
 [![license](https://img.shields.io/github/license/peshay/tpm.svg)](https://github.com/peshay/tpm/blob/master/LICENSE)
+
+[![Support maintenance via bunq](https://img.shields.io/badge/Support-bunq.me-0A6A47?style=flat-square)](https://bunq.me/ahuservices?description=tpm-sdk-maintenance-support)
+
+Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does **not** automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement.
 
 A Python Module for the [TeamPasswordManager API](http://teampasswordmanager.com/docs/api/)
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 [![Python version](https://img.shields.io/pypi/pyversions/tpm.svg)](https://pypi.python.org/pypi/tpm)
 [![license](https://img.shields.io/github/license/peshay/tpm.svg)](https://github.com/peshay/tpm/blob/master/LICENSE)
 
+A Python Module for the [TeamPasswordManager API](http://teampasswordmanager.com/docs/api/)
+
+## Support
+
 [![Support maintenance via bunq](https://img.shields.io/badge/Support-bunq.me-0A6A47?style=flat-square)](https://bunq.me/ahuservices?description=tpm-sdk-maintenance-support)
 
-Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does **not** automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement.
-
-A Python Module for the [TeamPasswordManager API](http://teampasswordmanager.com/docs/api/)
+Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does not automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement.
 
 Requires: requests
 


### PR DESCRIPTION
## Summary
- README top section now has one TPM-specific banner/header treatment.
- Added one small bunq support button near the top.
- Updated support wording to explicit freelancer maintenance/support framing.
- Explicitly states no automatic support/features/consulting/SLA/invoice entitlement.

## Support wording preview
"Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does **not** automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement."

## Tests
- not run (docs-only README change)

## Risk
- docs-only; README wording/top presentation only

## Follow-ups
- Acid review before merge
