### PR TITLE
docs(readme): standardize top layout and support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,12 @@
 > Modern Python SDK groundwork for TeamPasswordManager with safer API boundaries and maintainable packaging.
 
 [![Build Status](https://travis-ci.org/peshay/tpm.svg?branch=master)](https://travis-ci.org/peshay/tpm)
-[![Codecov](https://codecov.io/gh/peshay/tpm/branch/master/graph/badge.svg)](https://codecov.io/gh/peshay/tpm/branch/master)
-[![Scrutinizer](https://img.shields.io/scrutinizer/g/peshay/tpm.svg)](https://scrutinizer-ci.com/g/peshay/tpm/)
 [![Python version](https://img.shields.io/pypi/pyversions/tpm.svg)](https://pypi.python.org/pypi/tpm)
 [![license](https://img.shields.io/github/license/peshay/tpm.svg)](https://github.com/peshay/tpm/blob/master/LICENSE)
 
-A Python Module for the [TeamPasswordManager API](http://teampasswordmanager.com/docs/api/)
-
-## Support
-
 [![Support maintenance via bunq](https://img.shields.io/badge/Support-bunq.me-0A6A47?style=flat-square)](https://bunq.me/ahuservices?description=tpm-sdk-maintenance-support)
 
-Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does not automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement.
+A Python Module for the [TeamPasswordManager API](http://teampasswordmanager.com/docs/api/)
 
 Requires: requests
 
@@ -394,3 +388,7 @@ generate_password()
 get_version()
 get_latest_version()
 up_to_date()
+
+## Support
+
+Voluntary support helps fund ongoing freelance software maintenance for this SDK. It does not automatically grant support, feature delivery, consulting, SLA, or invoice-based engagement.


### PR DESCRIPTION
Align README top section with house style: heading-first layout, compact badge row, top support hint, and full support wording in a bottom `## Support` section.