### PR TITLE
Release 5.0.0: version bump + restore PyPI auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for PyPI Trusted Publishing (OIDC) — no API token needed.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/tpm.py
+++ b/tpm.py
@@ -41,7 +41,7 @@ from urllib.parse import quote_plus
 
 import requests
 
-__version__ = '4.2'
+__version__ = '5.0.0'
 
 # set logger
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Prepares the 5.0.0 release.

## Changes
- **Bump `__version__` to `5.0.0`** (read dynamically by `pyproject.toml`).
- **Restore automated PyPI publishing** via a new `.github/workflows/release.yml` that builds and publishes on tag push (`v*`) using **PyPI Trusted Publishing (OIDC)** — no stored API token. This replaces the old Travis `deploy: pypi` step that was removed during the modernization (#38).

## Why 5.0.0 (major)
This cycle includes breaking changes relative to 4.2:
- TLS `verify` now defaults to **True** (was hardcoded `False`)
- Minimum Python raised to **3.10** (dropped 3.6–3.9)
- Removed the unused `future` dependency

…plus the new **API v6** support (`TpmApiv6`).

## One-time setup required before tagging
PyPI Trusted Publishing must be configured once (no secret needed):
1. PyPI → project **tpm** → *Settings → Publishing → Add a trusted publisher* (GitHub Actions)
2. Owner: `peshay`, Repository: `tpm`, Workflow: `release.yml`, Environment: *(leave blank)*

## Release flow after merge
1. Merge this PR.
2. Tag the release commit on `master`: `git tag v5.0.0 && git push origin v5.0.0`
3. The Release workflow builds and publishes `tpm 5.0.0` to PyPI automatically.

https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt)_