### PR TITLE
Add categorised auto-generated release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# Configuration for GitHub's automatically generated release notes.
+# Applied when using "Generate release notes" while drafting a release,
+# so future releases get a clean, categorised changelog from PR titles.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🚨 Breaking Changes
+      labels:
+        - breaking
+        - breaking-change
+    - title: ✨ Features & Enhancements
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🏗️ Tooling, CI & Dependencies
+      labels:
+        - ci
+        - build
+        - dependencies
+        - testing
+    - title: 📝 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds `.github/release.yml` so GitHub's **"Generate release notes"** produces a clean, categorised changelog (Breaking Changes / Features / Bug Fixes / Tooling / Other) from PR titles and labels — instead of a flat, "ugly" list.

This is the lightweight, modern answer to the long-standing request for nicer/automated release notes. After this merges, drafting a release and clicking *Generate release notes* will group entries by the configured categories.

Resolves #13

https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt)_