### PR TITLE
Fix Release workflow tag trigger + add manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Match both the bare-number convention (5.0, 5.0.0) and a v-prefix.
+      - '[0-9]*'
+      - 'v[0-9]*'
+  # Allow manual runs (e.g. to (re)publish the current version on master).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why
The **5.0.0 release was published with the tag `5.0`** (the repo's existing bare-number convention: 4.0/4.1/4.2). The Release workflow only triggered on `v*`, so `5.0` didn't match and **the PyPI publish never ran** (0 workflow runs).

## Fix
- Broaden the tag trigger to match both conventions: `[0-9]*` (e.g. `5.0`, `5.0.0`) and `v[0-9]*` (e.g. `v5.0.0`).
- Add `workflow_dispatch` so a release can be (re)published manually from the Actions tab — needed to publish **this** release, since the already-pushed `5.0` tag won't retroactively trigger the workflow.

## After merge — publishing 5.0.0
Run **Actions → Release → Run workflow** (on `master`). It builds from `master` (where `__version__ == 5.0.0`) and publishes `tpm 5.0.0` to PyPI via Trusted Publishing. Future tags matching the convention will auto-publish.

https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrXQzoaPVn5EqLUoX67aZt)_